### PR TITLE
Added Support for metrics with no dimensions

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -95,7 +95,7 @@ func scrape(collector *cwCollector, ch chan<- prometheus.Metric) {
 			}
 		}
 
-		if (len(dimensions)>0){
+		if len(dimensions) > 0 || len(metric.ConfMetric.Dimensions) ==0 {
 			labels = append(labels, collector.Template.Task.Name)
 			params.Dimensions=dimensions
 			scrapeSingleDataPoint(collector,ch,params,metric,labels,svc)

--- a/config.yml
+++ b/config.yml
@@ -100,3 +100,11 @@ tasks:
       aws_dimensions: [FunctionName]
       aws_metric_name: Duration
       aws_statistics: [Maximum]
+
+ - name: ses_no_dimensions
+   default_region: us-east-1
+   metrics:
+    - aws_namespace: "AWS/SES"
+      aws_metric_name: Reputation.BounceRate
+      aws_statistics: [Maximum]
+      range_seconds: 3600


### PR DESCRIPTION
Added support for querying metrics that may not have dimensions -  for example Simple Email Service (SES). 

This PR adds also adds an example to the `config.yml` of a metric with no dimension.