### PR TITLE
Parallel fetch opto

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -6,9 +6,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/prometheus/client_golang/prometheus"
-	"time"
 	"regexp"
 	"strings"
+	"time"
 )
 
 func getLatestDatapoint(datapoints []*cloudwatch.Datapoint) *cloudwatch.Datapoint {
@@ -26,163 +26,160 @@ func getLatestDatapoint(datapoints []*cloudwatch.Datapoint) *cloudwatch.Datapoin
 // scrape makes the required calls to AWS CloudWatch by using the parameters in the cwCollector
 // Once converted into Prometheus format, the metrics are pushed on the ch channel.
 func scrape(collector *cwCollector, ch chan<- prometheus.Metric) {
-	session := session.Must(session.NewSession(&aws.Config{
+	awsSession := session.Must(session.NewSession(&aws.Config{
 		Region: aws.String(collector.Region),
 	}))
 
-	svc := cloudwatch.New(session)
+	svc := cloudwatch.New(awsSession)
 	for m := range collector.Template.Metrics {
-		metric := &collector.Template.Metrics[m]
+		scrapeMetric(collector, ch, &collector.Template.Metrics[m], svc)
+	}
+}
 
-		now := time.Now()
-		end := now.Add(time.Duration(-metric.ConfMetric.DelaySeconds) * time.Second)
+func scrapeMetric(collector *cwCollector, ch chan<- prometheus.Metric, metric *cwMetric, svc *cloudwatch.CloudWatch) {
+	now := time.Now()
+	end := now.Add(time.Duration(-metric.ConfMetric.DelaySeconds) * time.Second)
 
-		params := &cloudwatch.GetMetricStatisticsInput{
-			EndTime:   aws.Time(end),
-			StartTime: aws.Time(end.Add(time.Duration(-metric.ConfMetric.RangeSeconds) * time.Second)),
+	params := &cloudwatch.GetMetricStatisticsInput{
+		EndTime:   aws.Time(end),
+		StartTime: aws.Time(end.Add(time.Duration(-metric.ConfMetric.RangeSeconds) * time.Second)),
 
-			Period:     aws.Int64(int64(metric.ConfMetric.PeriodSeconds)),
-			MetricName: aws.String(metric.ConfMetric.Name),
-			Namespace:  aws.String(metric.ConfMetric.Namespace),
-			Dimensions: []*cloudwatch.Dimension{},
-			Statistics: []*string{},
-			Unit:       nil,
+		Period:     aws.Int64(int64(metric.ConfMetric.PeriodSeconds)),
+		MetricName: aws.String(metric.ConfMetric.Name),
+		Namespace:  aws.String(metric.ConfMetric.Namespace),
+		Dimensions: []*cloudwatch.Dimension{},
+		Statistics: []*string{},
+		Unit:       nil,
+	}
+
+	dimensions := []*cloudwatch.Dimension{}
+
+	//This map will hold dimensions name which has been already collected
+	valueCollected := map[string]bool{}
+
+	if len(metric.ConfMetric.DimensionsSelectRegex) == 0 {
+		metric.ConfMetric.DimensionsSelectRegex = map[string]string{}
+	}
+
+	//Check for dimensions who does not have either select or dimensions select_regex and make them select everything using regex
+	for _, dimension := range metric.ConfMetric.Dimensions {
+		_, found := metric.ConfMetric.DimensionsSelect[dimension]
+		_, found2 := metric.ConfMetric.DimensionsSelectRegex[dimension]
+		if !found && !found2 {
+			metric.ConfMetric.DimensionsSelectRegex[dimension] = ".*"
 		}
+	}
 
-		dimensions:=[]*cloudwatch.Dimension{}
+	for _, stat := range metric.ConfMetric.Statistics {
+		params.Statistics = append(params.Statistics, aws.String(stat))
+	}
 
-		//This map will hold dimensions name which has been already collected
-		valueCollected :=  map[string]bool{}
+	labels := make([]string, 0, len(metric.LabelNames))
 
+	// Loop through the dimensions selects to build the filters and the labels array
+	for dim := range metric.ConfMetric.DimensionsSelect {
+		for val := range metric.ConfMetric.DimensionsSelect[dim] {
+			dimValue := metric.ConfMetric.DimensionsSelect[dim][val]
 
-		if len(metric.ConfMetric.DimensionsSelectRegex) == 0 {
-			metric.ConfMetric.DimensionsSelectRegex =  map[string]string{}
-		}
-
-		//Check for dimensions who does not have either select or dimensions select_regex and make them select everything using regex
-		for _,dimension := range metric.ConfMetric.Dimensions {
-			_, found := metric.ConfMetric.DimensionsSelect[dimension]
-			_, found2 := metric.ConfMetric.DimensionsSelectRegex[dimension]
-			if !found && !found2 {
-				metric.ConfMetric.DimensionsSelectRegex[dimension]=".*"
+			// Replace $_target token by the actual URL target
+			if dimValue == "$_target" {
+				dimValue = collector.Target
 			}
+
+			dimensions = append(dimensions, &cloudwatch.Dimension{
+				Name:  aws.String(dim),
+				Value: aws.String(dimValue),
+			})
+
+			labels = append(labels, dimValue)
 		}
+	}
 
+	if len(dimensions) > 0 || len(metric.ConfMetric.Dimensions) == 0 {
+		labels = append(labels, collector.Template.Task.Name)
+		params.Dimensions = dimensions
+		scrapeSingleDataPoint(collector, ch, params, metric, labels, svc)
+	}
 
+	//If no regex is specified, continue
+	if len(metric.ConfMetric.DimensionsSelectRegex) == 0 {
+		return
+	}
 
-		for _, stat := range metric.ConfMetric.Statistics {
-			params.Statistics = append(params.Statistics, aws.String(stat))
-		}
+	// Get all the metric to select the ones who'll match the regex
+	result, err := svc.ListMetrics(&cloudwatch.ListMetricsInput{
+		MetricName: aws.String(metric.ConfMetric.Name),
+		Namespace:  aws.String(metric.ConfMetric.Namespace),
+	})
+	nextToken := result.NextToken
+	metrics := result.Metrics
+	totalRequests.Inc()
 
-		labels := make([]string, 0, len(metric.LabelNames))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
-		// Loop through the dimensions selects to build the filters and the labels array
-		for dim := range metric.ConfMetric.DimensionsSelect {
-			for val := range metric.ConfMetric.DimensionsSelect[dim] {
-				dimValue := metric.ConfMetric.DimensionsSelect[dim][val]
-
-				// Replace $_target token by the actual URL target
-				if dimValue == "$_target" {
-					dimValue = collector.Target
-				}
-
-				dimensions = append(dimensions, &cloudwatch.Dimension{
-					Name:  aws.String(dim),
-					Value: aws.String(dimValue),
-				})
-
-				labels = append(labels, dimValue)
-			}
-		}
-
-		if len(dimensions) > 0 || len(metric.ConfMetric.Dimensions) ==0 {
-			labels = append(labels, collector.Template.Task.Name)
-			params.Dimensions=dimensions
-			scrapeSingleDataPoint(collector,ch,params,metric,labels,svc)
-		}
-
-		//If no regex is specified, continue
-		if (len(metric.ConfMetric.DimensionsSelectRegex)==0){
-			continue
-		}
-
-		
-		// Get all the metric to select the ones who'll match the regex
+	for nextToken != nil {
 		result, err := svc.ListMetrics(&cloudwatch.ListMetricsInput{
 			MetricName: aws.String(metric.ConfMetric.Name),
 			Namespace:  aws.String(metric.ConfMetric.Namespace),
+			NextToken:  nextToken,
 		})
-		nextToken:=result.NextToken
-		metrics:=result.Metrics
-		totalRequests.Inc()
-
 		if err != nil {
 			fmt.Println(err)
 			continue
 		}
+		nextToken = result.NextToken
+		metrics = append(metrics, result.Metrics...)
+	}
 
-		for nextToken!=nil {
-			result, err := svc.ListMetrics(&cloudwatch.ListMetricsInput{
-				MetricName: aws.String(metric.ConfMetric.Name),
-				Namespace:  aws.String(metric.ConfMetric.Namespace),
-				NextToken: nextToken,
-			})		
-			if err != nil {
-				fmt.Println(err)
+	//For each metric returned by aws
+	for _, met := range result.Metrics {
+		labels := make([]string, 0, len(metric.LabelNames))
+		dimensions = []*cloudwatch.Dimension{}
+
+		//Try to match each dimensions to the regex
+		for _, dim := range met.Dimensions {
+			dimRegex := metric.ConfMetric.DimensionsSelectRegex[*dim.Name]
+			if dimRegex == "" {
+				dimRegex = "\\b" + strings.Join(metric.ConfMetric.DimensionsSelect[*dim.Name], "\\b|\\b") + "\\b"
+			}
+
+			match, _ := regexp.MatchString(dimRegex, *dim.Value)
+			if match {
+				dimensions = append(dimensions, &cloudwatch.Dimension{
+					Name:  aws.String(*dim.Name),
+					Value: aws.String(*dim.Value),
+				})
+				labels = append(labels, *dim.Value)
+
+			}
+		}
+
+		//Cheking if all dimensions matched
+		if len(labels) == len(metric.ConfMetric.Dimensions) {
+
+			//Checking if this couple of dimensions has already been scraped
+			if _, ok := valueCollected[strings.Join(labels, ";")]; ok {
 				continue
 			}
-			nextToken=result.NextToken
-			metrics=append(metrics,result.Metrics...)
-		}
-		
-		//For each metric returned by aws
-		for _,met := range result.Metrics {
-			labels := make([]string, 0, len(metric.LabelNames))
-			dimensions=[]*cloudwatch.Dimension{}
 
-			//Try to match each dimensions to the regex
-			for _,dim := range met.Dimensions {
-				dimRegex:=metric.ConfMetric.DimensionsSelectRegex[*dim.Name]
-				if(dimRegex==""){
-					dimRegex="\\b"+strings.Join(metric.ConfMetric.DimensionsSelect[*dim.Name],"\\b|\\b")+"\\b"
-				}
+			//If no, then scrape them
+			valueCollected[strings.Join(labels, ";")] = true
 
-				match,_:=regexp.MatchString(dimRegex,*dim.Value)
-				if match  {
-					dimensions=append(dimensions, &cloudwatch.Dimension{
-						Name:  aws.String(*dim.Name),
-						Value: aws.String(*dim.Value),
-					})
-					labels = append(labels, *dim.Value)
+			params.Dimensions = dimensions
 
-					
-				}
-			}
+			labels = append(labels, collector.Template.Task.Name)
+			scrapeSingleDataPoint(collector, ch, params, metric, labels, svc)
 
-			//Cheking if all dimensions matched
-			if len(labels) ==  len(metric.ConfMetric.Dimensions) {	
-
-				//Checking if this couple of dimensions has already been scraped
-				if _, ok := valueCollected[strings.Join(labels,";")]; ok {
-					continue
-				}
-
-				//If no, then scrape them
-				valueCollected[strings.Join(labels,";")]=true
-			
-				params.Dimensions = dimensions
-
-				labels = append(labels, collector.Template.Task.Name)	
-				scrapeSingleDataPoint(collector,ch,params,metric,labels,svc)
-			
-			}
 		}
 	}
 }
 
 //Send a single dataPoint to the Prometheus lib
-func scrapeSingleDataPoint(collector *cwCollector, ch chan<- prometheus.Metric,params *cloudwatch.GetMetricStatisticsInput,metric *cwMetric,labels []string,svc *cloudwatch.CloudWatch) error {
-	
+func scrapeSingleDataPoint(collector *cwCollector, ch chan<- prometheus.Metric, params *cloudwatch.GetMetricStatisticsInput, metric *cwMetric, labels []string, svc *cloudwatch.CloudWatch) error {
+
 	resp, err := svc.GetMetricStatistics(params)
 	totalRequests.Inc()
 
@@ -198,7 +195,6 @@ func scrapeSingleDataPoint(collector *cwCollector, ch chan<- prometheus.Metric,p
 	}
 	// Pick the latest datapoint
 	dp := getLatestDatapoint(resp.Datapoints)
-
 
 	if dp.Sum != nil {
 		ch <- prometheus.MustNewConstMetric(metric.Desc, metric.ValType, float64(*dp.Sum), labels...)


### PR DESCRIPTION
This PR changes the scrapes issued to Cloudwatch to all execute in parallel instead of series. It reduces the scrape time needed hugely in my case, going from just under 60 seconds to scrape 80 metrics to less than a second. This in turn means I can poll more frequently and get higher frequency stats imported from Cloudwatch.

The changes are quite small, I would suggest ignoring whitespace changes whilst viewing the diff.

Thx